### PR TITLE
Enables button event production

### DIFF
--- a/Events/ButtonClickedEventListener.cs
+++ b/Events/ButtonClickedEventListener.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using Core.Components.Input;
+using UnityEngine.UI;
+using FrameWork.Events.Input;
+using UnityEngine.Events;
+
+namespace Framework.Events.Input
+{
+    internal class ButtonClickListener<TPayload> : IEventListener<ControlEvent<TPayload>>, IDisposable where TPayload : struct
+    {
+        private readonly Button _button;
+        private readonly EventContainer<ControlEvent<TPayload>> _container;
+        private readonly IEventListener<ControlEvent<TPayload>> _inner;
+        private readonly Func<Button, TPayload> _selector;
+        private readonly bool _repeat;
+        private readonly List<UnityAction> _actions = new();
+
+        public IStateRetainer<ControlEvent<TPayload>> state => _container;
+
+        public ButtonClickListener(
+            Button button,
+            EventContainer<ControlEvent<TPayload>> container,
+            Func<Button, TPayload> selector,
+            bool repeat
+        )
+        {
+            _button = button;
+            _container = container;
+            _selector = selector;
+            _repeat = repeat;
+            _inner = new BaseEventListener<ControlEvent<TPayload>>(container, repeat);
+        }
+
+        public IDisposable Subscribe(EventHandler<ControlEvent<TPayload>> handler)
+        {
+            var subscription = _inner.Subscribe(handler);
+
+            UnityAction action = () =>
+            {
+                var payload = _selector(_button);
+                var evt = new ControlEvent<TPayload>
+                {
+                    value = payload,
+                    state = InputState.Performed
+                };
+
+                _container.publisher?.Invoke(_button, evt);
+            };
+
+            _actions.Add(action);
+            _button.onClick.AddListener(action);
+
+            // teardown just this subscription
+            return new ActionDisposable(() =>
+            {
+                subscription.Dispose();
+                _button.onClick.RemoveListener(action);
+                _actions.Remove(action);
+            });
+        }
+
+        public void Unsubscribe(EventHandler<ControlEvent<TPayload>> handler)
+        {
+            _inner.Unsubscribe(handler);
+        }
+
+        public void Dispose()
+        {
+            // remove all listeners we added
+            foreach (var a in _actions)
+            {
+                _button.onClick.RemoveListener(a);
+            }
+
+            _actions.Clear();
+        }
+    }
+}

--- a/Events/ButtonClickedEventListener.cs.meta
+++ b/Events/ButtonClickedEventListener.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 554c7bd020a94b6b8fc936b0a9fa87c1
+timeCreated: 1748355675

--- a/Events/ButtonEventProducer.cs
+++ b/Events/ButtonEventProducer.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Core.Components.Input;
+using UnityEngine.UI;
+
+namespace Framework.Events.Input
+{
+    public class ButtonControlEventProducer<TPayload> 
+        : IDisposableEventProducer<ControlEvent<TPayload>>
+        where TPayload : struct
+    {
+        private readonly EventContainer<ControlEvent<TPayload>> _container;
+        private readonly ButtonClickListener<TPayload>          _listener;
+
+        public IStateRetainer<ControlEvent<TPayload>> state    => _container;
+        public IEventListener<ControlEvent<TPayload>> listener => _listener;
+
+        public ButtonControlEventProducer(Button button, Func<Button, TPayload> selector)
+        {
+            if (button == null)
+            {
+                throw new ArgumentNullException(nameof(button));
+            }
+
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            _container = new EventContainer<ControlEvent<TPayload>>();
+            _listener  = new ButtonClickListener<TPayload>(button, _container, selector, false);
+        }
+
+        public void Publish(object sender, ControlEvent<TPayload> data)
+        {
+            _container.publisher?.Invoke(sender, data);
+        }
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+    }
+}

--- a/Events/ButtonEventProducer.cs.meta
+++ b/Events/ButtonEventProducer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 975336919d504223a5424fe0cb8a2aec
+timeCreated: 1748355745

--- a/Events/Extensions/ButtonExtension.cs
+++ b/Events/Extensions/ButtonExtension.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Framework.Events;
+using Framework.Events.Input;
+using UnityEngine.UI;
+
+namespace Core.Components.Input
+{
+    public static class ButtonExtensions
+    {
+        /// <summary>
+        /// Wraps this Button into a ControlEventProducer of any payload type.
+        /// </summary>
+        public static IDisposableEventProducer<ControlEvent<TPayload>> ToControlEventProducer<TPayload>(
+            this Button button,
+            Func<Button, TPayload> selector,
+            bool repeat = false
+        ) where TPayload : struct
+        {
+            return new ButtonControlEventProducer<TPayload>(button, selector);
+        }
+        
+        /// <summary>
+        /// Wraps this Button into a ControlEventProducer of any payload type.
+        /// </summary>
+        public static IDisposableEventProducer<ControlEvent<bool>> ToControlEventProducer(this Button button)
+        {
+            return new ButtonControlEventProducer<bool>(button, (ctx) => true);
+        }
+    }
+}

--- a/Events/Extensions/ButtonExtension.cs.meta
+++ b/Events/Extensions/ButtonExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 34157f7bc6a5405980485cfdd282e46e
+timeCreated: 1748356088


### PR DESCRIPTION
Adds the ability to produce control events from button clicks,
allowing to handle button interactions in a unified event-driven manner.

This introduces a new event producer and listener specifically
designed for Unity UI buttons. The producer wraps a button and
allows it to publish control events with custom payloads, which
can be wired to any event listener.
